### PR TITLE
Fix logger request context

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -53,7 +53,7 @@ static requestLogger(req, res, next) {
     const logMessage = `${req.method} ${req.path} - ${res.statusCode} (${duration}ms)`;
     
     if (res.statusCode >= 400) {
-      Logger.error(logMessage, undefined, 'HTTP');
+      Logger.error(logMessage, 'HTTP');
     } else {
       Logger.info(logMessage, 'HTTP');
     }


### PR DESCRIPTION
## Summary
- fix an incorrect parameter order when logging HTTP errors

## Testing
- `node -c index.js`
- `python3 -m py_compile app.py`